### PR TITLE
[e02] Specify number of threads for Blosc and OMP

### DIFF
--- a/e02/mib2x_test.yaml
+++ b/e02/mib2x_test.yaml
@@ -22,6 +22,7 @@ spec:
         value: 16Gi
     container:
       image: gcr.io/diamond-privreg/e02/mib2x:1.0
+      imagePullPolicy: Always
       env:
       - name: BLOSC_NTHREADS
         value: "{{ inputs.parameters.nprocs }}"

--- a/e02/mib2x_test.yaml
+++ b/e02/mib2x_test.yaml
@@ -16,8 +16,17 @@ spec:
     inputs:
       parameters:
       - name: config
+      - name: nprocs
+        value: 8
+      - name: memory
+        value: 16Gi
     container:
       image: gcr.io/diamond-privreg/e02/mib2x:1.0
+      env:
+      - name: BLOSC_NTHREADS
+        value: "{{ inputs.parameters.nprocs }}"
+      - name: OMP_NUM_THREADS
+        value: "{{ inputs.parameters.nprocs }}"
       command: [python]
       args:
       - "mib_convert.py"
@@ -30,11 +39,11 @@ spec:
       - name: main
         resources:
           requests:
-            cpu: "8"
-            memory: "16Gi"
+            cpu: "{{ inputs.parameters.nprocs }}"
+            memory: "{{ inputs.parameters.memory }}"
           limits:
-            cpu: "8"
-            memory: "16Gi"
+            cpu: "{{ inputs.parameters.nprocs }}"
+            memory: "{{ inputs.parameters.memory }}"
     volumes:
     - name: session
       hostPath:


### PR DESCRIPTION
This PR exposes the number of requested CPUs and set the environment variables `BLOSC_NTHREADS` and `OMP_NUM_THREADS` accordingly.

This also sets the image pull policy to `Always`.