### PR TITLE
Passing separate arguments to the mib container

### DIFF
--- a/e02/mib2x_test.yaml
+++ b/e02/mib2x_test.yaml
@@ -30,12 +30,8 @@ spec:
         value: 256
       - name: iBF
         value: true
-      - name: bin_sig_flag
-        value: true
       - name: bin_sig_factor
         value: 4
-      - name: bin_nav_flag
-        value: true
       - name: bin_nav_factor
         value: 4
       - name: create_json

--- a/e02/mib2x_test.yaml
+++ b/e02/mib2x_test.yaml
@@ -59,7 +59,19 @@ spec:
       command: [python]
       args:
       - "mib_convert.py"
-      - "{{ inputs.parameters.config }}"
+      - "{{ inputs.parameters.mib_path }}"
+      - "{{ inputs.parameters.auto_reshape == true ? '--auto-reshape' : '' }}"
+      - "{{ inputs.parameters.no_reshaping == true ? '--no-reshaping' : '' }}"
+      - "{{ inputs.parameters.use_fly_back == true ? '--use-fly-back' : '' }}"
+      - "{{ inputs.parameters.known_shape == true ? '--known-shape' : '' }}"
+      - "--scan-x={{ inputs.parameters.Scan_X }}"
+      - "--scan-y={{ inputs.parameters.Scan_Y }}"
+      - "{{ inputs.parameters.iBF == true ? '--ibf' : '' }}"
+      - "--bin-sig-factor={{ inputs.parameters.bin_sig_factor }}"
+      - "--bin-nav-factor={{ inputs.parameters.bin_nav_factor }}"
+      - "{{ inputs.parameters.create_json == true ? '--create-json' : '' }}"
+      - "{{ inputs.parameters.ptycho_config != '' ? '--ptycho-config=' + inputs.parameters.ptycho_config : '' }}"
+      - "{{ inputs.parameters.ptycho_template != '' ? '--ptycho-template=' + inputs.parameters.ptycho_template : '' }}"
       volumeMounts:
       - name: session
         mountPath: "{{ workflow.parameters.visitdir }}"

--- a/e02/mib2x_test.yaml
+++ b/e02/mib2x_test.yaml
@@ -41,7 +41,9 @@ spec:
       - name: create_json
         value: true
       - name: ptycho_config
+        value: ""
       - name: ptycho_template
+        value: ""
       - name: nprocs
         value: 8
       - name: memory


### PR DESCRIPTION
This PR updates the passing of arguments as separated fields to `mib_convert.py`.

It also makes `ptycho_config` and `ptycho_template` as optional arguments and remove redundant flags for binning.