### PR TITLE
Remove invalid conditionals in args section

### DIFF
--- a/e02/mib2x_test.yaml
+++ b/e02/mib2x_test.yaml
@@ -24,18 +24,28 @@ spec:
         value: false
       - name: known_shape
         value: false
+      - name: reshape_option
+        value: "{{= inputs.parameters.auto_reshape == true ? --auto-reshape :
+                    inputs.parameters.no_reshaping == true ? --no-reshaping :
+                    inputs.parameters.use_fly_back == true ? --use-fly-back :
+                    inputs.parameters.known_shape == true ? --known-shape : ''
+                 }}"
       - name: Scan_X
         value: 256
       - name: Scan_Y
         value: 256
       - name: iBF
         value: true
+      - name: ibf_option
+        value: "{{= inputs.parameters.iBF == true ? --ibf : '' }}"
       - name: bin_sig_factor
         value: 4
       - name: bin_nav_factor
         value: 4
       - name: create_json
         value: true
+      - name: create_json_option
+        value: "{{= inputs.parameters.create_json == true ? --create-json : '' }}"
       - name: ptycho_config
         value: ""
       - name: ptycho_template
@@ -60,18 +70,13 @@ spec:
       args:
       - "mib_convert.py"
       - "{{ inputs.parameters.mib_path }}"
-      - "{{ inputs.parameters.auto_reshape == true ? '--auto-reshape' : '' }}"
-      - "{{ inputs.parameters.no_reshaping == true ? '--no-reshaping' : '' }}"
-      - "{{ inputs.parameters.use_fly_back == true ? '--use-fly-back' : '' }}"
-      - "{{ inputs.parameters.known_shape == true ? '--known-shape' : '' }}"
+      - "{{ inputs.parameters.reshape_option }}"
       - "--scan-x={{ inputs.parameters.Scan_X }}"
       - "--scan-y={{ inputs.parameters.Scan_Y }}"
-      - "{{ inputs.parameters.iBF == true ? '--ibf' : '' }}"
+      - "{{ inputs.parameters.ibf_option }}"
       - "--bin-sig-factor={{ inputs.parameters.bin_sig_factor }}"
       - "--bin-nav-factor={{ inputs.parameters.bin_nav_factor }}"
-      - "{{ inputs.parameters.create_json == true ? '--create-json' : '' }}"
-      - "{{ inputs.parameters.ptycho_config != '' ? '--ptycho-config=' + inputs.parameters.ptycho_config : '' }}"
-      - "{{ inputs.parameters.ptycho_template != '' ? '--ptycho-template=' + inputs.parameters.ptycho_template : '' }}"
+      - "{{ inputs.parameters.create_json_option }}"
       volumeMounts:
       - name: session
         mountPath: "{{ workflow.parameters.visitdir }}"


### PR DESCRIPTION
This PR removes the ternary conditions in `container.args` which are apparently invalid, and attempts to move the conditionals to `inputs.parameters`.