### PR TITLE
Revert "Migrate local-path PVCs to netapp"

### DIFF
--- a/e02/templates/mib2x-auto.yaml
+++ b/e02/templates/mib2x-auto.yaml
@@ -15,7 +15,7 @@ spec:
       resources:
         requests:
           storage: 1Gi
-      storageClassName: netapp
+      storageClassName: local-path
   templates:
     - name: e02-mib2x-auto
       inputs:

--- a/httomo/templates/cor-sweep.yaml
+++ b/httomo/templates/cor-sweep.yaml
@@ -40,7 +40,7 @@ spec:
       resources:
         requests:
           storage: 1Gi
-      storageClassName: netapp
+      storageClassName: local-path
   arguments:
     parameters:
     - name: visitdir

--- a/httomo/templates/httomo-gpu-template-test.yaml
+++ b/httomo/templates/httomo-gpu-template-test.yaml
@@ -12,7 +12,7 @@ spec:
       resources:
         requests:
           storage: 1Gi
-      storageClassName: netapp
+      storageClassName: local-path
   arguments:
     parameters:
     - name: visitdir

--- a/ptypy/templates/ptypy-cpu-moonflower-test.yaml
+++ b/ptypy/templates/ptypy-cpu-moonflower-test.yaml
@@ -12,7 +12,7 @@ spec:
       resources:
         requests:
           storage: 1Gi
-      storageClassName: netapp
+      storageClassName: local-path
   arguments:
     parameters:
     - name: visitdir

--- a/ptypy/templates/ptypy-cpu-workflow-template.yaml
+++ b/ptypy/templates/ptypy-cpu-workflow-template.yaml
@@ -40,7 +40,7 @@ spec:
       resources:
         requests:
           storage: 1Gi
-      storageClassName: netapp
+      storageClassName: local-path
   arguments:
     parameters:
     - name: visitdir

--- a/ptypy/templates/ptypy-gpu-moonflower-test.yaml
+++ b/ptypy/templates/ptypy-gpu-moonflower-test.yaml
@@ -12,7 +12,7 @@ spec:
       resources:
         requests:
           storage: 1Gi
-      storageClassName: netapp
+      storageClassName: local-path
   arguments:
     parameters:
     - name: visitdir

--- a/ptypy/templates/ptypy-gpu-workflow-template.yaml
+++ b/ptypy/templates/ptypy-gpu-workflow-template.yaml
@@ -12,7 +12,7 @@ spec:
       resources:
         requests:
           storage: 1Gi
-      storageClassName: netapp
+      storageClassName: local-path
   arguments:
     parameters:
     - name: visitdir


### PR DESCRIPTION
Reverts DiamondLightSource/imaging-workflows#47

Quick testing with httomo-gpu-job has resulted in pending job with pod providing this error:
`MountVolume.SetUp failed for volume "pvc-d51b5c78-3120-4a4d-a929-ce25a350bee9" : rpc error: code = Internal desc = error mounting NFS volume 172.23.130.102:/trident_pvc_d51b5c78_3120_4a4d_a929_ce25a350bee9 on mountpoint /var/lib/kubelet/pods/c6554ce5-e99a-4e9c-a4ad-25ea28085a2a/volumes/kubernetes.io~csi/pvc-d51b5c78-3120-4a4d-a929-ce25a350bee9/mount: exit status 32`

Rolling back the change while the workflows and cloud team are investigating.