### PR TITLE
Use preferred instead of required

### DIFF
--- a/ptypy/templates/ptypy-cpu-moonflower-test.yaml
+++ b/ptypy/templates/ptypy-cpu-moonflower-test.yaml
@@ -78,9 +78,9 @@ spec:
       effect: NoSchedule
     affinity:
       nodeAffinity:
-       requiredDuringSchedulingIgnoredDuringExecution:
-         nodeSelectorTerms:
-         - matchExpressions:
+       preferredDuringSchedulingIgnoredDuringExecution:
+       - preference:
+           matchExpressions:
            - key: nodegroup
              operator: In
              values:

--- a/ptypy/templates/ptypy-cpu-workflow-template.yaml
+++ b/ptypy/templates/ptypy-cpu-workflow-template.yaml
@@ -105,9 +105,9 @@ spec:
       effect: NoSchedule
     affinity:
       nodeAffinity:
-       requiredDuringSchedulingIgnoredDuringExecution:
-         nodeSelectorTerms:
-         - matchExpressions:
+       preferredDuringSchedulingIgnoredDuringExecution:
+       - preference:
+           matchExpressions:
            - key: nodegroup
              operator: In
              values:


### PR DESCRIPTION
when scheduling CPU workflows on dedicated nodes