### PR TITLE
Remove default param values for recon in CoR sweep

### DIFF
--- a/httomo/schemas/cor-sweep-param.json
+++ b/httomo/schemas/cor-sweep-param.json
@@ -367,23 +367,23 @@
           "$ref": "#/$defs/SweepConfig"
         },
         "sinogram_order": {
-          "default": false,
           "title": "Sinogram Order",
           "type": "boolean"
         },
         "algorithm": {
-          "default": "gridrec",
           "title": "Algorithm",
           "type": "string"
         },
         "init_recon": {
-          "default": null,
           "title": "Init Recon",
           "type": "null"
         }
       },
       "required": [
-        "center"
+        "center",
+        "sinogram_order",
+        "algorithm",
+        "init_recon"
       ],
       "title": "TomopyReconConfigParams",
       "type": "object"


### PR DESCRIPTION
The default values are unnecessary for the tomo GUI's usage of the parameter schema and associated workflow template, and the default values are related to pipeline validation issues in the tomo GUI (likely existing since the merge of #152), so its removal causes no issues and provides a convenient workaround for the validation issue.