### PR TITLE
bug fix - altering the path from which python is called

### DIFF
--- a/e02/templates/mib2x-auto-virtual-images.yaml
+++ b/e02/templates/mib2x-auto-virtual-images.yaml
@@ -181,8 +181,8 @@ spec:
 
           todo, checks = check_dataset(hdf5_files,hdf5_timestamps,[no_vir,no_dpc,no_par])
           for item,x in enumerate(todo):
-            cmd_list.append('python /home/ruska/py4DSTEM_Virtual_Image.py --hdf5-path %s --disk-thrs-low %f --disk-thrs-up %f --virtual-images %s --dpc-images %s --plax %s --mask-path %s' %(hdf5_files[todo[item]],0.05,0.2,checks[0][todo[item]],checks[1][todo[item]],checks[2][todo[item]],"/home/ruska/29042024_12bitmask2.h5"))
-            logging.append('python /home/ruska/py4DSTEM_Virtual_Image.py --hdf5-path %s --disk-thrs-low %f --disk-thrs-up %f --virtual-images %s --dpc-images %s --plax %s --mask-path %s' %(hdf5_files[todo[item]],0.05,0.2,checks[0][todo[item]],checks[1][todo[item]],checks[2][todo[item]],"/home/ruska/29042024_12bitmask2.h5"))
+            cmd_list.append('/usr/bin/python /home/ruska/py4DSTEM_Virtual_Image.py --hdf5-path %s --disk-thrs-low %f --disk-thrs-up %f --virtual-images %s --dpc-images %s --plax %s --mask-path %s' %(hdf5_files[todo[item]],0.05,0.2,checks[0][todo[item]],checks[1][todo[item]],checks[2][todo[item]],"/home/ruska/29042024_12bitmask2.h5"))
+            logging.append('/usr/bin/python /home/ruska/py4DSTEM_Virtual_Image.py --hdf5-path %s --disk-thrs-low %f --disk-thrs-up %f --virtual-images %s --dpc-images %s --plax %s --mask-path %s' %(hdf5_files[todo[item]],0.05,0.2,checks[0][todo[item]],checks[1][todo[item]],checks[2][todo[item]],"/home/ruska/29042024_12bitmask2.h5"))
 
           #ToDo think about this printing in the context of an Error
           #this should be try statement 


### PR DESCRIPTION
Currently the code gives the following error:
No such file or directory
when running the line code below:
/home/ruska/python /home/ruska/py4DSTEM_Virtual_Image.py --hdf5-path /dls/e02/data/2025/cm40603-4/processing/Merlin/workflows_testing/20250912_160650/20250912_160650_data.hdf5 --disk-thrs-low 0.050000 --disk-thrs-up 0.200000 --virtual-images True --dpc-images True --plax True --mask-path /home/ruska/29042024_12bitmask2.h5

hopefully changing the python directory to its actual location will help fix the above error:
/usr/bin/python