### PR TITLE
Updating ptyrex_basic workflow to use latest container

### DIFF
--- a/e02/schema/ptyrex_Schema.json
+++ b/e02/schema/ptyrex_Schema.json
@@ -16,18 +16,11 @@
             "title": "Scan number",
             "type": "integer"
         },
-        "proj_start": {
+        "proj_number": {
             "default": null,
             "maximum": 10000000,
             "minimum": 0,
-            "title": "Proj Start",
-            "type": "integer"
-        },
-        "proj_end": {
-            "default": null,
-            "maximum": 10000000,
-            "minimum": 0,
-            "title": "Proj End",
+            "title": "Proj Number",
             "type": "integer"
         },
         "nprocs": {
@@ -40,7 +33,7 @@
         "memory": {
             "type": "string",
             "pattern": "^[0-9]+[GMK]i$",
-            "default": "16Gi"
+            "default": "32Gi"
         }
     },
     "title": "RexSubmission"

--- a/e02/schema/ptyrex_ui.json
+++ b/e02/schema/ptyrex_ui.json
@@ -23,22 +23,17 @@
             },
             {
               "type": "Control",
-              "label": "Projection start number",
-              "scope": "#/properties/proj_start"
+              "label": "Projection number",
+              "scope": "#/properties/proj_number"
             },
             {
               "type": "Control",
-              "label": "Projection end number",
-              "scope": "#/properties/proj_end"
-            },
-            {
-              "type": "Control",
-              "label": "Number of Processors",
+              "label": "Requested number of Processors",
               "scope": "#/properties/nprocs"
             },
             {
               "type": "Control",
-              "label": "Amount of memory",
+              "label": "Requested memory",
               "scope": "#/properties/memory"
             }
           ]

--- a/e02/templates/ptyrex_basic.yaml
+++ b/e02/templates/ptyrex_basic.yaml
@@ -22,15 +22,11 @@ spec:
         configMapKeyRef:
          name: sessionspaces
          key: data_directory
-  ##
   volumes:
   - name: session
     hostPath:
       path: "{{`{{ workflows.parameters.visitdir}}`}}"
       type: Directory
-  ##
-  #should claim and use a volume called workflows within the visit directory called workflows
-  ##
   volumeClaimTemplates:
   - metadata:
       name: tmpdir
@@ -40,50 +36,77 @@ spec:
         requests:
           storage: 1Gi
       storageClassName: netapp
-  ##
   templates:
-    - name: ptyrex-container
-      steps:
-      - - name: ptyrex
-          template: ptyrex
-  ##
-    - name: ptyrex
-      inputs:
-        parameters:
-        - name: config_json
-          value: "{{`{{workflows.parameters.config_json}}`}}"
-        - name: scan_number
-          value: "{{`{{workflows.parameters.scan_number}}`}}"
-        - name: projection_start
-          value: "{{`{{workflows.parameters.proj_start}}`}}"
-        - name: projection_end
-          value: "{{`{{workflows.parameters.proj_end}}`}}"
-        - name: nprocs
-          value: "{{`{{workflows.parameters.nprocs}}`}}"
-        - name: memory
-          value: "{{`{{ workflow.parameters.memory }}`}}" 
-      script:
-        image: gitlab.diamond.ac.uk:5050/scisoft/ptychography/dimtools/mib2x #I am using this image to test the workflow generates its inputs correctly not to run anything at the moment
-        imagePullPolicy: Always
-        env:
-          - name: BLOSC_NTHREADS
-            value: "{{`{{ inputs.parameters.nprocs }}`}}"
-          - name: OMP_NUM_THREADS
-            value: "{{`{{ inputs.parameters.nprocs }}`}}"
-        volumeMounts:
-        - name: tmpdir
-          mountPath: /tmp
-        - name: session
-          mountPath: "{{`{{workflows.parameters.visitdir}}`}}"
-        command: [sh]
-        source: |
-          #!/bin/sh
-          set -e
+  - name: ptyrex-container
+    inputs:
+      parameters:
+      - name: config_json
+        value: "{{`{{workflow.parameters.config_json}}`}}"
+      - name: scan_number
+        value: "{{`{{workflow.parameters.scan_number}}`}}"
+      - name: projection_start
+        value: "{{`{{workflow.parameters.proj_number}}`}}"
+      - name: nprocs
+        value: "{{`{{workflow.parameters.nprocs}}`}}"
+      - name: memory
+        value: "{{`{{ workflow.parameters.memory }}`}}" 
+    container:
+      image: gitlab.diamond.ac.uk:5050/scisoft/ptychography/dimtools/ptyrex:latest
+      imagePullPolicy: Always
+      env:
+      - name: CUPY_CACHE_DIR
+        value: /tmp/.cupy/kernel_cache
+      - name: MKL_NUM_THREADS
+        value: "1"
+      - name: NUMEXPR_NUM_THREADS
+        value: "1"
+      - name: OMP_NUM_THREADS
+        value: "1"
+      command: 
+      - "/opt/conda/bin/mpirun"
+      args: 
+      - "-np"
+      - "{{`{{ inputs.parameters.nprocs }}`}}"
+      - "/home/ptyrex_recon"
+      - "-c"
+      - "{{`{{ inputs.parameters.config_json }}`}}"
+      - "-s"
+      - "{{`{{ inputs.parameters.scan_number }}`}}"
+      - "-p"
+      - "{{`{{ inputs.parameters.proj_number }}`}}"
 
-          cmd=("python mpiexec -np nprocs ptyrex_recon -c {{`{{workflows.parameters.config_json}}`}} -s {{`{{workflows.parameters.scan_number}}`}} -p {{`{{workflows.parameters.projection_start}}`}}-{{`{{workflows.parameters.projection_end}}`}}")
-          echo "Executing: ${cmd[@]}"
-          #exec "${cmd[@]}"
-
-
-
+      volumeMounts:
+      - name: tmpdir
+        mountPath: /tmp
+      - name: session
+        mountPath: "{{`{{ workflow.parameters.visitdir }}`}}"
+    podSpecPatch: |
+      containers:
+      - name: main
+        resources:
+          requests:
+            cpu: "{{`{{ inputs.parameters.nprocs }}`}}"
+            memory: "{{`{{ inputs.parameters.memory }}`}}"
+            nvidia.com/gpu: "{{`{{ inputs.parameters.nprocs }}`}}"
+          limits:
+            cpu: "{{`{{ inputs.parameters.nprocs }}`}}"
+            memory: "{{`{{ inputs.parameters.memory }}`}}"
+            nvidia.com/gpu: "{{`{{ inputs.parameters.nprocs }}`}}"
+    tolerations:
+    - key: nvidia.com/gpu
+      operator: Exists
+      effect: NoSchedule
+    - key: nodetype
+      operator: Equal
+      value: gpu
+      effect: NoSchedule
+    - key: nodegroup
+      operator: Equal
+      value: workflows
+      effect: NoSchedule
+    volumes:
+    - name: session
+      hostPath:
+        path:  "{{`{{ workflow.parameters.visitdir }}`}}"
+        type: Directory
 

--- a/e02/templates/ptyrex_basic.yaml
+++ b/e02/templates/ptyrex_basic.yaml
@@ -44,7 +44,7 @@ spec:
         value: "{{`{{workflow.parameters.config_json}}`}}"
       - name: scan_number
         value: "{{`{{workflow.parameters.scan_number}}`}}"
-      - name: projection_start
+      - name: projection_number
         value: "{{`{{workflow.parameters.proj_number}}`}}"
       - name: nprocs
         value: "{{`{{workflow.parameters.nprocs}}`}}"
@@ -73,7 +73,7 @@ spec:
       - "-s"
       - "{{`{{ inputs.parameters.scan_number }}`}}"
       - "-p"
-      - "{{`{{ inputs.parameters.proj_number }}`}}"
+      - "{{`{{ inputs.parameters.projection_number }}`}}"
 
       volumeMounts:
       - name: tmpdir


### PR DESCRIPTION
Previously there was issue whereby there was a mismatch between the cuda versions of ptyrex and the kubernetes. Meaning the workflow could not run.

Now that the container has been updated to use the correct version of cuda, this workflow should now run correctly. furthermore the workflow has been simplified just to reconstruction a single projection. 

Other changes include other bug fixes such as using mpi instead of direct reference to python which should speed up reconstruction.